### PR TITLE
Update to the downloads page for Debian 12

### DIFF
--- a/web/downloads.md
+++ b/web/downloads.md
@@ -61,7 +61,7 @@ binaries directly.
             <td colspan="2">Debian 9 (Stretch) </td>
             <td>6.3.0/5.0.1 </td>
             <td>Ada, C, C++, Fortran, Obj-C, Obj-C++, OCaml </td>
-            <td rowspan="3">9 (gdb, libassuan, libgcrypt, libgpg-error, libksba, libnpth, nsis, win-iconv, zlib) </td>
+            <td rowspan="4">9 (gdb, libassuan, libgcrypt, libgpg-error, libksba, libnpth, nsis, win-iconv, zlib) </td>
         </tr>
         <tr>
             <td colspan="2">Debian 10 (Buster) </td>

--- a/web/downloads.md
+++ b/web/downloads.md
@@ -53,7 +53,7 @@ binaries directly.
             <td><a href="https://cygwin.com/cgi-bin2/package-grep.cgi?grep=mingw64-x86_64&arch=x86_64"> many</a> </td>
         </tr>
         <tr>
-            <td style="text-align:center;" rowspan="3">
+            <td style="text-align:center;" rowspan="4">
                 <strong><a href="#debian"><img src="../logos/debian-logo.png" title="Debian logo" alt="Debian logo" width="32"></a>
                 <br>
                 <a href="#debian">Debian</a></strong>

--- a/web/downloads.md
+++ b/web/downloads.md
@@ -66,7 +66,7 @@ binaries directly.
         <tr>
             <td colspan="2">Debian 10 (Buster) </td>
             <td>8.3.0/6.0.0 </td>
-            <td rowspan="2">Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
+            <td rowspan="3">Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
         </tr>
         <tr>
             <td colspan="2">Debian 11 (Bullseye) </td>

--- a/web/downloads.md
+++ b/web/downloads.md
@@ -73,6 +73,10 @@ binaries directly.
             <td>10.2.1/8.0.0 </td>
         </tr>
         <tr>
+            <td colspan="2">Debian 12 (Bookworm) </td>
+            <td>12.0.0/10.0.0 </td>
+        </tr>
+        <tr>
             <td style="text-align:center;" rowspan="2">
                 <strong><a href="#fedora"><img
                             src="../logos/fedora-logo.png"


### PR DESCRIPTION
The `-dumpfullversion` flag is broken so I used `printf("%i.%i.%i", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)` to extract the gcc version