### PR TITLE
Split GCC and Clang versions in download table

### DIFF
--- a/web/downloads.md
+++ b/web/downloads.md
@@ -16,7 +16,7 @@ much easier to set up than building from source.
             </th>
             <th>Version </th>
             <th>Host </th>
-            <th>GCC / mingw-w64 Version </th>
+            <th>GCC / Clang / mingw-w64 Versions </th>
             <th>Languages </th>
             <th>Additional Software in Package Manager </th>
         </tr>
@@ -32,8 +32,9 @@ much easier to set up than building from source.
             <td>Linux</td>
             <td>
                 <a href="https://archlinux.org/packages/extra/x86_64/mingw-w64-gcc/" class="urlextern"
-                    title="https://archlinux.org/packages/extra/x86_64/mingw-w64-gcc/" rel="nofollow">15.2.0</a>/<a
-                    href="https://archlinux.org/packages/extra/any/mingw-w64-crt/" class="urlextern"
+                    title="https://archlinux.org/packages/extra/x86_64/mingw-w64-gcc/" rel="nofollow">15.2.0</a>
+                  / - /
+                    <a href="https://archlinux.org/packages/extra/any/mingw-w64-crt/" class="urlextern"
                     title="https://archlinux.org/packages/extra/any/mingw-w64-crt/" rel="nofollow">13.0.0</a>
             </td>
             <td>Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
@@ -49,10 +50,13 @@ much easier to set up than building from source.
             <td>Rolling</td>
             <td>Windows</td>
             <td>
-                <a href="https://cygwin.com/packages/summary/mingw64-x86_64-gcc-src.html" class="urlextern"
-                    title="https://cygwin.com/packages/summary/mingw64-x86_64-gcc-src.html" rel="nofollow">13.4.0</a>/<a
-                    href="https://cygwin.com/packages/summary/mingw64-x86_64-runtime-src.html" class="urlextern"
-                    title="https://cygwin.com/packages/summary/mingw64-x86_64-runtime-src.html" rel="nofollow">13.0.0</a>
+                <a href="https://cygwin.com/packages/summary/mingw64-x86_64-gcc-core.html" class="urlextern"
+                    title="https://cygwin.com/packages/summary/mingw64-x86_64-gcc-core.html" rel="nofollow">13.4.0</a>
+                  / <a href="https://cygwin.com/packages/summary/mingw64-x86_64-clang.html" class="urlextern"
+                    title="https://cygwin.com/packages/summary/mingw64-x86_64-clang.html" rel="nofollow">20.1.8</a>
+                  / <a
+                    href="https://cygwin.com/packages/summary/mingw64-x86_64-runtime.html" class="urlextern"
+                    title="https://cygwin.com/packages/summary/mingw64-x86_64-runtime.html" rel="nofollow">13.0.0</a>
             </td>
             <td>C, C++, Fortran, Obj-C </td>
             <td><a href="https://cygwin.com/cgi-bin2/package-grep.cgi?grep=mingw64-x86_64&arch=x86_64"> many</a> </td>
@@ -64,17 +68,17 @@ much easier to set up than building from source.
                 <a href="#debian">Debian</a></strong>
             </td>
             <td colspan="2">Debian 11 (Bullseye) </td>
-            <td>10.2.1/8.0.0 </td>
+            <td>10.2.1 / - / 8.0.0 </td>
             <td rowspan="3">Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
             <td rowspan="3">9 (gdb, libassuan, libgcrypt, libgpg-error, libksba, libnpth, nsis, win-iconv, zlib) </td>
         </tr>
         <tr>
             <td colspan="2">Debian 12 (Bookworm) </td>
-            <td>12.0.0/10.0.0 </td>
+            <td>12.0.0 / - / 10.0.0 </td>
         </tr>
         <tr>
             <td colspan="2">Debian 13 (Trixie) </td>
-            <td>14.2.0/12.0.0 </td>
+            <td>14.2.0 / - / 12.0.0 </td>
         </tr>
         <tr>
             <td style="text-align:center;" rowspan="2">
@@ -84,13 +88,13 @@ much easier to set up than building from source.
                         href="#fedora">Fedora</a></strong>
             </td>
             <td colspan="2">Fedora 42</td>
-            <td>14.2.1/12.0.0</td>
+            <td>14.2.1 / - / 12.0.0</td>
             <td rowspan="2">Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
             <td rowspan="2"><a href="https://packages.fedoraproject.org/search?query=mingw64"> many</td>
         </tr>
         <tr>
             <td colspan="2">Fedora 43</td>
-            <td>15.2.1/13.0.0</td>
+            <td>15.2.1 / - / 13.0.0</td>
         </tr>
         <tr>
             <td style="text-align:center;">
@@ -98,7 +102,7 @@ much easier to set up than building from source.
             </td>
             <td>Rolling</td>
             <td>Windows</td>
-            <td>16.x.x/master</td>
+            <td>16.x.x / - / master</td>
             <td>C, C++, Fortran, Obj-C, Obj-C++</td>
             <td>20 (boost, bzip2, cmake, curl, gdb, iconv, lua, make, meson, muon, ncurses, ninja,
                 openssl, python, sqlite3, upx, xmake, yasm, zlib, zstd) </td>
@@ -113,7 +117,8 @@ much easier to set up than building from source.
                 <a href="https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/mingw-w64.rb"
                     class="urlextern"
                     title="https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/mingw-w64.rb"
-                    rel="nofollow">15.2.0</a>/<a
+                    rel="nofollow">15.2.0</a>
+                  / - / <a
                     href="https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/mingw-w64.rb"
                     class="urlextern"
                     title="https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/m/mingw-w64.rb"
@@ -128,7 +133,7 @@ much easier to set up than building from source.
             </td>
             <td>20251202</td>
             <td>Windows, Linux, macOS</td>
-            <td>LLVM 21.1.7/master</td>
+            <td>- / 22.1.4 / master</td>
             <td>C, C++</td>
             <td>make, Python</td>
         </tr>
@@ -146,7 +151,8 @@ much easier to set up than building from source.
                 <a href="https://github.com/macports/macports-ports/blob/master/cross/x86_64-w64-mingw32-gcc/Portfile"
                     class="urlextern"
                     title="https://github.com/macports/macports-ports/blob/master/cross/x86_64-w64-mingw32-gcc/Portfile"
-                    rel="nofollow">15.2.0</a>/<a
+                    rel="nofollow">15.2.0</a>
+                  / - / <a
                     href="https://github.com/macports/macports-ports/blob/master/cross/mingw-w64/Portfile"
                     class="urlextern"
                     title="https://github.com/macports/macports-ports/blob/master/cross/mingw-w64/Portfile"
@@ -161,7 +167,7 @@ much easier to set up than building from source.
             </td>
             <td>Rolling </td>
             <td>Windows</td>
-            <td>15.2.0/13.0.0 </td>
+            <td>15.2.0 / - / 13.0.0 </td>
             <td>C, C++, Fortran </td>
             <td>4 (gdb, libiconf, python, zlib) </td>
         </tr>
@@ -177,7 +183,11 @@ much easier to set up than building from source.
             <td>
                 <a href="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-gcc/PKGBUILD" class="urlextern"
                     title="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-gcc/PKGBUILD"
-                    rel="nofollow">15.2.0</a>/<a
+                    rel="nofollow">15.2.0</a>
+                  / <a href="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-llvm/PKGBUILD" class="urlextern"
+                    title="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-llvm/PKGBUILD"
+                    rel="nofollow">22.1.4</a>
+                  / <a
                     href="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-crt/PKGBUILD"
                     class="urlextern"
                     title="https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-crt/PKGBUILD"
@@ -193,17 +203,17 @@ much easier to set up than building from source.
                             title="Ubuntu logo" alt="Ubuntu logo" width="32"></a><br><a href="#ubuntu"> Ubuntu</a></strong>
             </td>
             <td colspan="2">22.04 Jammy Jellyfish </td>
-            <td>10.3.0/8.0.0 </td>
+            <td>10.3.0 / - / 8.0.0 </td>
             <td rowspan="3">Ada, C, C++, Fortran, Obj-C, Obj-C++ </td>
             <td rowspan="3">9 (gdb, libassuan, libgcrypt, libgpg-error, libksba, libnpth, nsis, win-iconv, zlib) </td>
         </tr>
         <tr>
             <td colspan="2">24.04 Noble Numbat </td>
-            <td>13.2.0/11.0.1 </td>
+            <td>13.2.0 / - / 11.0.1 </td>
         </tr>
         <tr>
             <td colspan="2">25.10 Questing Quokka </td>
-            <td>13.2.0/12.0.0 </td>
+            <td>13.2.0 / - / 12.0.0 </td>
         </tr>
         <tr>
             <td style="text-align:center;">
@@ -211,7 +221,7 @@ much easier to set up than building from source.
             </td>
             <td>2.7.0</td>
             <td>Windows</td>
-            <td>15.2.0/14.0.0</td>
+            <td>15.2.0 / - / 14.0.0</td>
             <td>C, C++, Fortran</td>
             <td>
                 10
@@ -236,7 +246,7 @@ much easier to set up than building from source.
             <td>
                 <a href="https://winlibs.com/#download-release" class="urlextern"
                     title="https://winlibs.com/"
-                    rel="nofollow">15.2.0/13.0.0</a>
+                    rel="nofollow">15.2.0 / 19.1.7 / 13.0.0</a>
             </td>
             <td>Ada, C, C++, Fortran, Obj-C, Obj-C++, Assembler</td>
             <td>Package manager: work in progress (will offer > 2500 packages)</td>


### PR DESCRIPTION
The version field of Clang is only set for distributions that provide dedicated Clang with default mingw-w64 targets, which are Cygwin, MSYS2, and Winlibs. Although Clang can always be used as a cross compiler, it is not set for distributions that provide Clang with default Linux or macOS targets.